### PR TITLE
Check for clobber issues within a single catalog

### DIFF
--- a/lib/puppet/type/windows_env.rb
+++ b/lib/puppet/type/windows_env.rb
@@ -12,7 +12,7 @@ Puppet::Type.newtype(:windows_env) do
     # Cannot have two resources in clobber mode on the same var
     @mergemode[user] ||= {}
     last = @mergemode[user][var]
-    raise "Multiple resources are managing the same environment variable but at least one is in clobber mergemode. (Offending resources: #{resource}, #{last})" if (resource[:mergemode] == :clobber && last) || (last && last[:mergemode] == :clobber)
+    raise "Multiple resources are managing the same environment variable but at least one is in clobber mergemode. (Offending resources: #{resource}, #{last})" if (!last.nil? && last.catalog == resource.catalog) && ((resource[:mergemode] == :clobber && last) || (last && last[:mergemode] == :clobber))
     @mergemode[user][var] = resource
 
     # Cannot have two resources with different types on the same var


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

There is code that checks for multiple windows_env instances with
clobber enabled on the same variable. This check makes use of the
instance variable @mergemode, which gets the entire contents of the
previously instantiated resource.

This was causing issues in the case where Puppet restarts mid-way
through its run to account for agent-specified environment conflicts.
When Puppet does this, it does not clear, or re-instantiate, its
types. This caused all instance variables to stick around for the next
run.

The check was looking at the instance variable that it already made;
which was technically coming from a different catalog (a different,
albeit stunted, Puppet run).

This commit fixes the issue by adding some logic that checks to see that
we are only validating for duplicate clobber within the same catalog.

Ideally, this fix shouldn't be needed because Puppet should
re-instantiate its types when it restarts a Puppet run.